### PR TITLE
Bump version

### DIFF
--- a/src/requirements.yml
+++ b/src/requirements.yml
@@ -17,7 +17,6 @@
   name: dev_ssh_access
 - src: https://github.com/cisagov/ansible-role-freeipa-client
   name: freeipa_client
-  version: improvement/use-imdsv2
 - src: https://github.com/cisagov/ansible-role-hardening
   name: harden
 - src: https://github.com/cisagov/ansible-role-htop

--- a/src/requirements.yml
+++ b/src/requirements.yml
@@ -17,6 +17,7 @@
   name: dev_ssh_access
 - src: https://github.com/cisagov/ansible-role-freeipa-client
   name: freeipa_client
+  version: improvement/use-imdsv2
 - src: https://github.com/cisagov/ansible-role-hardening
   name: harden
 - src: https://github.com/cisagov/ansible-role-htop

--- a/src/version.txt
+++ b/src/version.txt
@@ -1,1 +1,1 @@
-__version__ = "0.2.1"
+__version__ = "0.2.1+build.1"

--- a/src/version.txt
+++ b/src/version.txt
@@ -1,1 +1,1 @@
-__version__ = "0.2.1+build.1"
+__version__ = "0.2.1+build.2"


### PR DESCRIPTION
## 🗣 Description ##

This PR bumps the version to include the changes from cisagov/ansible-role-freeipa-client#28.

## 💭 Motivation and context ##

The changes from cisagov/ansible-role-freeipa-client#28 increase security.

## 🧪 Testing ##

All `pre-commit` hooks pass.  I also built and deployed a new OpenVPN AMI with these changes to our COOL staging environment and verified that they function as expected.

## ✅ Pre-review checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
* [x] Build and test a new staging AMI.
* [x] Revert to using the default branch of [cisagov/ansible-role-freeipa-client](https://github.com/cisagov/ansible-role-freeipa-client).


## ✅ Pre-merge checklist ##

* [x] Build a new production AMI.