### PR TITLE
Correct default user name in `shell` provisioner

### DIFF
--- a/src/packer.pkr.hcl
+++ b/src/packer.pkr.hcl
@@ -217,7 +217,7 @@ build {
     # We need to call bash here because after hardening /tmp has the
     # noexec bit set on it.
     execute_command = "chmod +x {{ .Path }}; sudo env {{ .Vars }} bash {{ .Path }} ; rm -f {{ .Path }}"
-    inline          = ["sed -i '/^users:/ {N; s/users:.*/users: []/g}' /etc/cloud/cloud.cfg", "rm --force /etc/sudoers.d/90-cloud-init-users", "rm --force /root/.ssh/authorized_keys", "/usr/sbin/userdel --remove --force admin"]
+    inline          = ["sed -i '/^users:/ {N; s/users:.*/users: []/g}' /etc/cloud/cloud.cfg", "rm --force /etc/sudoers.d/90-cloud-init-users", "rm --force /root/.ssh/authorized_keys", "/usr/sbin/userdel --remove --force ubuntu"]
     skip_clean      = true
   }
 }


### PR DESCRIPTION
## 🗣 Description ##

This pull request corrects the default user name used in the final `shell` provisioner.  This PR is an add-on to #113.

## 💭 Motivation and context ##

The final `shell` provisioner is intended to delete the default user, but with the incorrect user name that doesn't happen.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.